### PR TITLE
Remove errors in initialization

### DIFF
--- a/app/scripts/controllers/library.js
+++ b/app/scripts/controllers/library.js
@@ -37,14 +37,6 @@ angular.module('helmeditor2App')
       }
     };
 
-    // search for the monomers as needed
-    var searchMonomers = function () {
-      if (!MonomerLibraryService.initComplete) {
-        return [];
-      }
-      return MonomerLibraryService.searchMonomers(self.activeType, self.search);
-    };
-
     // convert the class to the right class name for the background color
     var convertBackgroundColorClass = function (prop) {
       switch (prop) {
@@ -105,19 +97,33 @@ angular.module('helmeditor2App')
       }
     };
 
+    // search for the monomers as needed
+    var searchMonomers = function () {
+      if (!MonomerLibraryService.initComplete) {
+        return [];
+      }
+      return MonomerLibraryService.searchMonomers(self.activeType, self.search);
+    };
+
     // retrieve the current active type
     var getActiveType = function () {
-      return MonomerLibraryService.getMonomersByType(self.activeType);
+      if (MonomerLibraryService.initComplete) {
+        return MonomerLibraryService.getMonomersByType(self.activeType);
+      }
     };
 
     // get the categories of the current group selected
     var getCategories = function (group) {
-      return group.categories || [];
+      if (group) {
+        return group.categories || [];
+      }
     };
 
     // get the monomers of the current group selected
     var getMonomers = function (group) {
-      return group.monomers || [];
+      if (group) {
+        return group.monomers || [];
+      }
     };
 
     // return true if the given name is the active category

--- a/app/scripts/controllers/library.js
+++ b/app/scripts/controllers/library.js
@@ -45,11 +45,6 @@ angular.module('helmeditor2App')
       return MonomerLibraryService.searchMonomers(self.activeType, self.search);
     };
 
-    // list the monomers by the selection
-    var listMonomers = function () {
-      return [];
-    };
-
     // convert the class to the right class name for the background color
     var convertBackgroundColorClass = function (prop) {
       switch (prop) {
@@ -138,7 +133,6 @@ angular.module('helmeditor2App')
     // expose the methods we want to 
     self.setViewVisible = setViewVisible;
     self.searchMonomers = searchMonomers;
-    self.listMonomers = listMonomers;
     self.convertBackgroundColorClass = convertBackgroundColorClass;
     self.convertFontColorClass = convertFontColorClass;
     self.convertShapeClass = convertShapeClass;

--- a/app/scripts/controllers/library.js
+++ b/app/scripts/controllers/library.js
@@ -25,6 +25,9 @@ angular.module('helmeditor2App')
     self.searchViewVisible = true;
     self.exploreViewVisible = false;
 
+    // expose the service directly so it can be used
+    self.libraryService = MonomerLibraryService;
+
     // allow toggling
     var setViewVisible = function (view) {
       if (view === 'search') {

--- a/app/views/main.html
+++ b/app/views/main.html
@@ -14,128 +14,130 @@
     </div>
     <div class='row full-height'>
       <div class='col-md-3 library-column' ng-controller='LibraryCtrl as library'>
-        <div class="btn-group btn-group-sm btn-group-justified button-row" role="group" aria-label="Type selection">
-          <div 
-            class="btn-group btn-group-sm" 
-            role="group"
-            ng-repeat="polymerType in library.polymerTypes">
-            <button 
-              class="btn btn-secondary btn-selector"
-              ng-class="{activetype: library.activeType === polymerType}"
-              ng-click="library.activeType = polymerType">
-              {{ polymerType }}
-            </button>
+        <div class="full-height" ng-show="library.libraryService.initComplete">
+          <div class="btn-group btn-group-sm btn-group-justified button-row" role="group" aria-label="Type selection">
+            <div 
+              class="btn-group btn-group-sm" 
+              role="group"
+              ng-repeat="polymerType in library.polymerTypes">
+              <button 
+                class="btn btn-secondary btn-selector"
+                ng-class="{activetype: library.activeType === polymerType}"
+                ng-click="library.activeType = polymerType">
+                {{ polymerType }}
+              </button>
+            </div>
           </div>
-        </div>
 
-        <div class="sub-group">
-          <!-- allow either searching or exploring -->
-          <div class="btn-group btn-group-sm btn-group-justified button-row" role="group" aria-label="View selection">
-            <div class="btn-group btn-group-sm" role="group">
-              <button 
-                class="btn btn-secondary btn-selector-view"
-                ng-class="{activetype: library.searchViewVisible}"
-                ng-click="library.setViewVisible('search')">
-                Search
-              </button>
-            </div>
-            <div class="btn-group btn-group-sm" role="group">
-              <button 
-                class="btn btn-secondary btn-selector-view"
-                ng-class="{activetype: library.exploreViewVisible}"
-                ng-click="library.setViewVisible('explore')">
-                Explore
-              </button>
-            </div>
-          </div>
           <div class="sub-group">
-            <div ng-show="library.searchViewVisible" style="height: 100%">
-              <div class="input-row">
-                <label class="search-label">Search: </label>
-                <input class="search-input" type="text" ng-model="library.search">
+            <!-- allow either searching or exploring -->
+            <div class="btn-group btn-group-sm btn-group-justified button-row" role="group" aria-label="View selection">
+              <div class="btn-group btn-group-sm" role="group">
+                <button 
+                  class="btn btn-secondary btn-selector-view"
+                  ng-class="{activetype: library.searchViewVisible}"
+                  ng-click="library.setViewVisible('search')">
+                  Search
+                </button>
               </div>
-              <div class="monomer-listing">
-                <div 
-                  ng-repeat="monomer in library.searchMonomers()"
-                  class="monomer-holder">
-                  <div
-                    ng-class="library.convertBackgroundColorClass(monomer._backgroundColor) + ' ' + library.convertShapeClass(monomer._shape)"
-                    class="monomer">
+              <div class="btn-group btn-group-sm" role="group">
+                <button 
+                  class="btn btn-secondary btn-selector-view"
+                  ng-class="{activetype: library.exploreViewVisible}"
+                  ng-click="library.setViewVisible('explore')">
+                  Explore
+                </button>
+              </div>
+            </div>
+            <div class="sub-group">
+              <div ng-show="library.searchViewVisible" style="height: 100%">
+                <div class="input-row">
+                  <label class="search-label">Search: </label>
+                  <input class="search-input" type="text" ng-model="library.search">
+                </div>
+                <div class="monomer-listing">
+                  <div 
+                    ng-repeat="monomer in library.searchMonomers()"
+                    class="monomer-holder">
+                    <div
+                      ng-class="library.convertBackgroundColorClass(monomer._backgroundColor) + ' ' + library.convertShapeClass(monomer._shape)"
+                      class="monomer">
+                    </div>
+                    <span 
+                      class="monomer-name noselect"
+                      ng-class="library.convertFontColorClass(monomer._fontColor)">
+                      {{monomer._name}}
+                    </span>
                   </div>
-                  <span 
-                    class="monomer-name noselect"
-                    ng-class="library.convertFontColorClass(monomer._fontColor)">
-                    {{monomer._name}}
-                  </span>
                 </div>
               </div>
-            </div>
-            <div ng-show="library.exploreViewVisible" class="monomer-view">
-              <!-- display each category under this that exists -->
-              <div 
-                class="category-holder" 
-                ng-repeat="category in library.getCategories(library.getActiveType())">
-                <button 
-                  class="btn btn-secondary btn-category" 
-                  ng-click="library.activeCategory = category._name"
-                  ng-class="{activetype: library.categoryActive(category._name)}">
-                  {{ category._name }}
-                </button>
-                <!-- display sub elements -->
-                <div
-                  class="sub-selection-group"
-                  ng-show="library.activeCategory === category._name">
-                  <!-- display any sub-categories that may exist -->
-                  <div 
-                    class="sub-group"
-                    ng-show="library.getCategories(category).length > 0">
-                    <div
-                      class="sub-category-holder"
-                      ng-repeat="subCategory in library.getCategories(category)">
-                      <button
-                        class="btn btn-secondary btn-category"
-                        ng-click="library.activeSubCategory = subCategory._name"
-                        ng-class="{activetype: library.subCategoryActive(subCategory._name)}">
-                        {{ subCategory._name }}
-                      </button>
+              <div ng-show="library.exploreViewVisible" class="monomer-view">
+                <!-- display each category under this that exists -->
+                <div 
+                  class="category-holder" 
+                  ng-repeat="category in library.getCategories(library.getActiveType())">
+                  <button 
+                    class="btn btn-secondary btn-category" 
+                    ng-click="library.activeCategory = category._name"
+                    ng-class="{activetype: library.categoryActive(category._name)}">
+                    {{ category._name }}
+                  </button>
+                  <!-- display sub elements -->
+                  <div
+                    class="sub-selection-group"
+                    ng-show="library.activeCategory === category._name">
+                    <!-- display any sub-categories that may exist -->
+                    <div 
+                      class="sub-group"
+                      ng-show="library.getCategories(category).length > 0">
                       <div
-                        ng-show="library.activeSubCategory === subCategory._name">
+                        class="sub-category-holder"
+                        ng-repeat="subCategory in library.getCategories(category)">
+                        <button
+                          class="btn btn-secondary btn-category"
+                          ng-click="library.activeSubCategory = subCategory._name"
+                          ng-class="{activetype: library.subCategoryActive(subCategory._name)}">
+                          {{ subCategory._name }}
+                        </button>
                         <div
-                          class="monomer-listing monomer-explorer"
-                          ng-show="library.getMonomers(subCategory).length > 0 || library.getCategories(subCategory).length === 0">
+                          ng-show="library.activeSubCategory === subCategory._name">
                           <div
-                            ng-repeat="monomer in library.getMonomers(subCategory)"
-                            class="monomer-holder">
+                            class="monomer-listing monomer-explorer"
+                            ng-show="library.getMonomers(subCategory).length > 0 || library.getCategories(subCategory).length === 0">
                             <div
-                              ng-class="library.convertBackgroundColorClass(monomer._backgroundColor) + ' ' + library.convertShapeClass(monomer._shape)"
-                              class="monomer">
+                              ng-repeat="monomer in library.getMonomers(subCategory)"
+                              class="monomer-holder">
+                              <div
+                                ng-class="library.convertBackgroundColorClass(monomer._backgroundColor) + ' ' + library.convertShapeClass(monomer._shape)"
+                                class="monomer">
+                              </div>
+                              <span 
+                                class="monomer-name noselect"
+                                ng-class="library.convertFontColorClass(monomer._fontColor)">
+                                {{monomer._name}}
+                              </span>
                             </div>
-                            <span 
-                              class="monomer-name noselect"
-                              ng-class="library.convertFontColorClass(monomer._fontColor)">
-                              {{monomer._name}}
-                            </span>
                           </div>
                         </div>
                       </div>
                     </div>
-                  </div>
-                  <!-- display if there are just monomers in here -->
-                  <div 
-                    class="monomer-listing monomer-explorer"
-                    ng-show="library.getMonomers(category).length > 0 || library.getCategories(category).length === 0">
+                    <!-- display if there are just monomers in here -->
                     <div 
-                      ng-repeat="monomer in library.getMonomers(category)"
-                      class="monomer-holder">
-                      <div
-                        ng-class="library.convertBackgroundColorClass(monomer._backgroundColor) + ' ' + library.convertShapeClass(monomer._shape)"
-                        class="monomer">
+                      class="monomer-listing monomer-explorer"
+                      ng-show="library.getMonomers(category).length > 0 || library.getCategories(category).length === 0">
+                      <div 
+                        ng-repeat="monomer in library.getMonomers(category)"
+                        class="monomer-holder">
+                        <div
+                          ng-class="library.convertBackgroundColorClass(monomer._backgroundColor) + ' ' + library.convertShapeClass(monomer._shape)"
+                          class="monomer">
+                        </div>
+                        <span 
+                          class="monomer-name noselect"
+                          ng-class="library.convertFontColorClass(monomer._fontColor)">
+                          {{monomer._name}}
+                        </span>
                       </div>
-                      <span 
-                        class="monomer-name noselect"
-                        ng-class="library.convertFontColorClass(monomer._fontColor)">
-                        {{monomer._name}}
-                      </span>
                     </div>
                   </div>
                 </div>
@@ -143,26 +145,9 @@
             </div>
           </div>
         </div>
-        <!-- <label class="search-label">Monomer Search:</label>
-        <input class="search-input" type="text" ng-model="library.search.monomer">
-        <br><br>
-        <p> {{ library.getSearchBoxResult() }} </p>
-        <form>
-          Make a selection: <br>
-          <select>
-          <option ng-repeat="x in library.getPolymerIdList()">{{x}}</option>
-          </select>
-        </form>
-
-        <button class="stdNucleotideBtnA"> A </button>
-
-        <button class="stdNucleotideBtnC"> C </button>
-
-        <button class="stdNucleotideBtnG"> G </button>
-
-        <button class="stdNucleotideBtnT"> T </button>
-
-        <button class="stdNucleotideBtnU"> U </button> -->
+        <div class="full-height" ng-show="!library.libraryService.initComplete">
+          <h4 class='text-center'>Loading Monomer Library</h3>
+        </div>
       </div>
       <div class='col-md-9 canvas-column'>
         <div class='row canvas-row-top'>


### PR DESCRIPTION
When the library controller is first loaded, it was trying to access properties and objects that didn't exist in the monomer library service yet. This is changed, and the view is also changed to only show the library explorer once it's initialized.